### PR TITLE
Link to accounts tab

### DIFF
--- a/views/dashboard/signatories.ejs
+++ b/views/dashboard/signatories.ejs
@@ -7,7 +7,7 @@
     <div class="signatory-panel">
         <% signatories.forEach(sig => { %>
             <p>
-                <a href="https://stackexchange.com/users/<%= sig.se_acct_id %>">
+                <a href="https://stackexchange.com/users/<%= sig.se_acct_id %>?tab=accounts">
                     <%= sig.display_name %>
                     <% if (sig.is_moderator) { %>
                         <span title="moderator">&diams;</span>


### PR DESCRIPTION
When clicking on a signatory, link to the accounts tab of the network profile. This makes it much easier to see what site(s) the user is active on and (if they are a moderator) moderates.